### PR TITLE
Exclude mock_ files from coverage and create new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ build:
 
 ## Properties
 
-Name     | Type   | Default                 | Description
--------- | ------ | ----------------------- | -------------------
-token    | string |                         | Your Coveralls repository token.
+| Name  | Type   | Default | Description                      |
+| ----- | ------ | ------- | -------------------------------- |
+| token | string |         | Your Coveralls repository token. |
 
 ## Changelog
+
+### 2.1.0
+
+- Exclude mock_*.go files from the coverage profile
 
 ### 1.1.1
 

--- a/run.sh
+++ b/run.sh
@@ -35,7 +35,7 @@ for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -pa
     echo "Parsing directory: $dir"
     go test -v -tags=unit -covermode=count -coverprofile=profile.out $dir || err=1
     if [ -f profile.out ]; then
-      cat profile.out | grep -v "mode: count" >> profile.cov
+      cat profile.out | grep -v "mode: count" | grep -v "/mock_\w\+.go" >> profile.cov
       rm profile.out
     fi
   fi

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: goveralls
-version: 2.0.0
+version: 2.1.0
 description: uploads go coverage to coveralls
 keywords:
   - go


### PR DESCRIPTION
As a lot of applications in go start to use https://github.com/vektra/mockery with the the following config `-inpkg -case "underscore"`, some files named `mock_xxx.go` are present in the various packages.
The current coverage profile is taking them into account. It should not. This PR remove them from the profile by adding a grep exclusion.

New resulting version: 2.1.0